### PR TITLE
fix: add default to non-required value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
   trim:
     description: 'Trims output'
     required: false
+    default: 'false'
 outputs:
   content:
     description: 'File content'


### PR DESCRIPTION
Looks like there isn't a default for the `trim` input, so it fails with a YAML parse error [if not provided](https://github.com/owenvoke/blade-fontawesome/runs/2674868262?check_suite_focus=true#step:3:4).

This defaults to `false` (has to be a string for input defaults), which is the same as previous versions.