### PR TITLE
Bump to `node16`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   content:
     description: 'File content'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
`node12` is deprecated with following warning appearing in CI:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: cachix/install-nix-action, cachix/cachix-action, juliangruber/read-file-action, cachix/cachix-action
```