### PR TITLE
[DEVOPS-2284] bump actions-core to v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # read-file-action
 
 Read file contents.
+Note: Forked to control release schedule and changes.
 
 ## Usage
 
@@ -8,7 +9,7 @@ Read file contents.
 steps:
   - name: Read package.json
     id: package
-    uses: juliangruber/read-file-action@v1
+    uses: travelaudience/read-file-action@v1
     with:
       path: ./package.json
   - name: Echo package.json

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish": false
   },
   "dependencies": {
-    "@actions/core": "^1.3.0"
+    "@actions/core": "^1.10.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.20.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.3",
   "license": "MIT",
   "description": "Read file contents",
-  "repository": "juliangruber/read-file-action",
+  "repository": "travelaudience/read-file-action",
   "scripts": {
     "test": "prettier-standard index.js && standard index.js",
     "build": "ncc build index.js",


### PR DESCRIPTION
GitHub Actions: Deprecating save-state and set-output commands
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/