### PR TITLE
Bump to `node20`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   content:
     description: 'File content'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
`node16` is deprecated and the following warning appears in CI:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: juliangruber/read-file-action@v1 [...]
```
See also: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/