### PR TITLE
Bump to `node24`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   content:
     description: 'File content'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
`node20` is deprecated and the following warning is shown in the CI:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 
20 and may not work as expected: juliangruber/read-file-action@v1. Actions will 
be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if 
updated versions of these actions are available that support Node.js 24.
```
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/